### PR TITLE
Merge feature/launch-initialization into main

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -6,8 +6,10 @@ import { CronExpression } from "@nestjs/schedule";
 config();
 const env: NodeJS.ProcessEnv = process.env;
 
+const production: boolean = false;
+
 export default {
-  production: false,
+  production: production,
 
   httpPort: Number(env.HTTP_PORT),
   jwtSecret: env.JWT_SECRET,
@@ -30,7 +32,7 @@ export default {
     password: env.DB_PASSWORD,
     entities: ["dist/**/*.entity{.ts,.js}"],
     options: { trustServerCertificate: true },
-    synchronize: true
+    synchronize: !production
   },
 
   chatMessageDeleteTask: {

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -35,6 +35,13 @@ export default {
     synchronize: !production
   },
 
+  startup: {
+    rootUser: {
+      username: env.ROOT_USERNAME,
+      password: env.ROOT_PASSWORD
+    }
+  },
+
   chatMessageDeleteTask: {
     enabled: true,
     schedule: CronExpression.EVERY_WEEK,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { OrganizationsModule } from './modules/core/organizations/organizations.
 import { RoomsModule } from './modules/core/rooms/rooms.module';
 import { AppWebSocketModule } from './modules/core/app-web-socket/app-web-socket.module';
 import { MapperModule } from './modules/shared/mapper/mapper.module';
+import { StartupModule } from './startup/startup.module';
 
 import appConfig from './app.config';
 
@@ -25,7 +26,8 @@ import appConfig from './app.config';
     OrganizationsModule,
     RoomsModule,
     AppWebSocketModule,
-    MapperModule
+    MapperModule,
+    StartupModule
   ]
 })
 export class AppModule { }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,7 @@ import appConfig from './app.config';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot({ ...appConfig.typeOrm, synchronize: !appConfig.production }),
+    TypeOrmModule.forRoot(appConfig.typeOrm),
     ScheduleModule.forRoot(),
     JwtAuthModule,
     AuthModule,

--- a/src/modules/core/user-secrets/entities/user-secret.entity.ts
+++ b/src/modules/core/user-secrets/entities/user-secret.entity.ts
@@ -16,7 +16,7 @@ export class UserSecret {
   public userId: number;
 
 
-  @OneToOne(() => User)
+  @OneToOne(() => User, { onDelete: "CASCADE" })
   @JoinColumn()
   public user?: User;
 

--- a/src/startup/startup.module.ts
+++ b/src/startup/startup.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UserSecretsModule } from 'src/modules/core/user-secrets/user-secrets.module';
+import { UsersModule } from 'src/modules/core/users/users.module';
+import { StartupService } from './startup.service';
+
+@Module({
+  imports: [
+    UsersModule,
+    UserSecretsModule
+  ],
+  providers: [StartupService]
+})
+export class StartupModule { }

--- a/src/startup/startup.service.ts
+++ b/src/startup/startup.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { Role } from 'src/models/auth/role';
+import { UserSecret } from 'src/modules/core/user-secrets/entities/user-secret.entity';
+import { User } from 'src/modules/core/users/entities/user.entity';
+import { UsersService } from 'src/modules/core/users/users.service';
+import { generateUserSecret } from 'src/utils/hash-utils';
+
+import appConfig from 'src/app.config';
+import { UserSecretsService } from 'src/modules/core/user-secrets/user-secrets.service';
+
+@Injectable()
+export class StartupService implements OnApplicationBootstrap {
+  private readonly _logger = new Logger(StartupService.name);
+
+  constructor(private _usersService: UsersService, private _userSecretsService: UserSecretsService) { }
+
+  public async onApplicationBootstrap(): Promise<void> {
+    this._logger.log("Performing startup tasks");
+
+    try {
+      await this.createRootUser();
+      await this.setAllUsersOffline();
+    }
+    catch(error) {
+      this._logger.error(error.message || error);
+      throw error;
+    }
+  }
+
+  private async createRootUser(): Promise<void> {
+    this._logger.log("Checking if root user should be created...");
+    const adminExists: boolean = await this._usersService.hasAnyWithModel({ role: Role.Administrator });
+
+    if(adminExists) {
+      this._logger.log("One or more Administrator users exist - skipping root user creation.");
+      return;
+    }
+
+    this._logger.log("Creating root user...");
+    const rootUsername: string = appConfig.startup.rootUser.username;
+    const rootPassword: string = appConfig.startup.rootUser.password;
+
+    if(!rootUsername || !rootPassword) {
+      throw new Error("Root user username and/or password has not been defined!");
+    }
+
+    let rootUser = new User({ role: Role.Administrator, username: rootUsername });
+    rootUser = await this._usersService.add(rootUser);
+
+    const secret: UserSecret = await generateUserSecret(rootUser.id, rootPassword);
+    await this._userSecretsService.add(secret);
+
+    this._logger.log("Root user created & inserted into database successfully.");
+  }
+
+  private async setAllUsersOffline(): Promise<void> {
+    this._logger.log("Resetting all users to 'offline' status...");
+    const users: User[] = await this._usersService.getAll();
+
+    if(users) {
+      for(let i = 0; i < users.length; i++) {
+        users[i].isOnline = false;
+      }
+    }
+
+    await this._usersService.updateMany(users);
+    this._logger.log("All users set to 'offline' status successfully.");
+  }
+}


### PR DESCRIPTION
This branch implements features for the server to perform initial startup tasks when launched.
When the server starts, it will:
- Check if there are any Administrator-role users in the database, and if not, will create a new root Administrator user with a username & password defined from environment variables. This allows the server to be deployed to new environments/databases with a new Administrator user ready to go.
- Set the `isOnline` status of all users in the database to `false`. This is so that if the server goes offline, any users who are marked as "online" in the database will be re-synchronized back to "offline" when the server restarts.